### PR TITLE
Add health middleware for load balancer

### DIFF
--- a/middlewares/health.js
+++ b/middlewares/health.js
@@ -1,0 +1,4 @@
+module.exports = function (req, res, next) {
+  res.statusCode = 200
+  return res.end()
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -24,6 +24,10 @@ module.exports = {
     ethUrl: process.env.ETH_NODE_URL || 'ws://35.153.248.198:8546'
   },
 
+  serverMiddleware: [
+    { path: '/health', handler: '~/middlewares/health.js' }
+  ],
+
   loading: { color: '#7E66F4', height: '3px' },
 
   css: ['bootstrap/dist/css/bootstrap.css'],


### PR DESCRIPTION
Resolves #26 

- Create nuxt.js `health` middleware
- Set `health` middleware to respond `200` on path `/health`.